### PR TITLE
adjust for changed behavior of nfs-utils on jammy

### DIFF
--- a/mapfs_mounter.go
+++ b/mapfs_mounter.go
@@ -166,6 +166,13 @@ func (m *mapfsMounter) Mount(env dockerdriver.Env, remote string, target string,
 		if versionFloat <= 0 {
 			return dockerdriver.SafeError{SafeDescription: "\"version\" must be a positive numeric value"}
 		}
+		if versionFloat == 3.0 {
+			version = "3"
+			logger.Info("detected version parameter set to `3.0`, NFSv3 does not have a minor version available, correcting to `3`")
+		}
+		if versionFloat > 3.0 && versionFloat < 4.0 {
+			return dockerdriver.SafeError{SafeDescription: fmt.Sprintf("NFSv3 does not use minor versions. NFSv %v does not exist", versionFloat)}
+		}
 
 		mountOptions = mountOptions + ",vers=" + version
 	}


### PR DESCRIPTION
[#186911574]

fix error for supported nfs versions

earlier versions of nfs-utils ( specifically the deb we shipped for xenial ) handled specifying `mount -t nfs -o vers=3.0`. This apparently was undesired behavior as Steve Dickson points out here:
https://bugzilla.redhat.com/show_bug.cgi?id=1522633

```
There are no minor versions with NFS v3
```

Currently when people upgrade the underlying CF that runs nfsv3driver from xenial to jammy, previously working mounts for a service instance that got created with `version: 3.0` parameter fail when the app tries to mount the share.

This tries to remedy those pains by:

automatically correcting `3.0` to `3` because it is numerically equal. It will print a warning about it in the logs but it will accept the param.

When the code detects a version 3.0 > $VERSION < 4.0, it will NOT autocorrect to `3` assuming that the input was done in mistake ( e.g. trying to specify 4.1 )